### PR TITLE
Fixing Raw URL in plugin file

### DIFF
--- a/plugins/Unraid-Nvidia.plg
+++ b/plugins/Unraid-Nvidia.plg
@@ -50,7 +50,7 @@ rm -rf /tmp/mediabuild
 The 'source' file.
 -->
 <FILE Name="/boot/config/plugins/&name;/&name;-&version;.txz" Run="upgradepkg --install-new">
-<URL>https://raw.github.com/&github;/master/archive/&name;-&version;.txz</URL>
+<URL>https://raw.githubusercontent.com/&github;/master/archive/&name;-&version;.txz</URL>
 <MD5>&md5;</MD5>
 </FILE>
 


### PR DESCRIPTION
Something has changed on github and plugins are breaking. This URL should work